### PR TITLE
fix: mitigate shell injection in discussion workflow (MSRC 110700)

### DIFF
--- a/.github/workflows/on-discussion-created.yml
+++ b/.github/workflows/on-discussion-created.yml
@@ -47,9 +47,17 @@ jobs:
         if: github.event_name == 'discussion'
         env:
           DISPATCH_TOKEN: ${{ secrets.FOUNDRY_DOCS_DISPATCH_TOKEN }}
+          DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          DISCUSSION_TITLE: ${{ github.event.discussion.title }}
+          DISCUSSION_URL: ${{ github.event.discussion.html_url }}
         run: |
-          curl -s -X POST \
+          PAYLOAD=$(jq -n \
+            --arg title "$DISCUSSION_TITLE" \
+            --arg url "$DISCUSSION_URL" \
+            --argjson number "$DISCUSSION_NUMBER" \
+            '{event_type: "community-discussion", client_payload: {number: $number, title: $title, url: $url}}')
+          curl -fsS -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $DISPATCH_TOKEN" \
             https://api.github.com/repos/nicholasdbrady/foundry-docs/dispatches \
-            -d "{\"event_type\":\"community-discussion\",\"client_payload\":{\"number\":${{ github.event.discussion.number }},\"title\":$(echo '${{github.event.discussion.title }}' | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),\"url\":\"${{ github.event.discussion.html_url}}\"}}"
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

Fixes a critical shell injection vulnerability in `.github/workflows/on-discussion-created.yml` (MSRC Case 110700).

## Vulnerability

The "Dispatch to foundry-docs" step interpolated user-controlled `${{ github.event.discussion.* }}` expressions directly into a bash `run:` block. Since GitHub Actions expands `${{ }}` **before** the shell runs, an attacker could create a discussion with a crafted title to break out of single quotes and execute arbitrary commands on the runner — potentially exfiltrating the `FOUNDRY_DOCS_DISPATCH_TOKEN` secret.

**Attack vector**: Any user can create a discussion on this public repository (no permissions required).

## Fix

- **Moved all user-controlled expressions to `env:` variables** — values are set as environment variables and are NOT subject to shell interpretation
- **JSON payload built with `jq`** using `--arg`/`--argjson` — proper escaping of all special characters (quotes, backticks, `$`, etc.)
- **`curl -fsS`** — fail loudly on HTTP errors instead of silent failure

## Testing

The fix has been validated through code review and rubber-duck analysis. The `jq` tool is pre-installed on GitHub-hosted `ubuntu-latest` runners.